### PR TITLE
Adapt code after updating dependencies

### DIFF
--- a/jupyter/notebooks/LTIBootCamp.ipynb
+++ b/jupyter/notebooks/LTIBootCamp.ipynb
@@ -646,7 +646,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "deep_linking_response_token = jwt.encode(deep_linking_response, notebook_private_key, 'RS256').decode()\n",
+    "deep_linking_response_token = jwt.encode(deep_linking_response, notebook_private_key, 'RS256')\n",
     "\n",
     "print(deep_linking_response_token)"
    ]

--- a/server/lti_platform.py
+++ b/server/lti_platform.py
@@ -1,10 +1,9 @@
 from flask import Flask, jsonify, request, render_template, redirect, send_from_directory, abort
 from ltiplatform.ltiplatform_manager import LTIPlatform
-from ltiplatform.ltiutil import fc, fdlc
-from keys import keys_manager
-from random import randrange
+from ltiplatform.ltiutil import fdlc
 from accesstoken.token_manager import check_token, new_token
 import jwt
+
 
 platform = LTIPlatform('http://localhost:5000')
 app = Flask(__name__)
@@ -99,9 +98,9 @@ def content_item_launch(tool_id, nonce=None, redirect_uri=None):
 @app.route("/tool/<context_id>/dlr", methods=['POST'])
 def content_item_return(context_id):
     encoded_jwt = request.form['jws_token']
-    unverified = jwt.decode(encoded_jwt, verify=False)
+    unverified = jwt.decode(encoded_jwt, options={'verify_signature': False})
     tool = platform.get_tool(unverified['iss'])
-    deep_linking_res = jwt.decode(encoded_jwt, 
+    deep_linking_res = jwt.decode(encoded_jwt,
        key=tool.getPublicKey().exportKey(), 
        algorithms=['RS256'],
        audience=request.url_root.rstrip('/'))


### PR DESCRIPTION
Indeed as noticed at #21, updating dependencies #19 brought with itself some versioning problems, specially with PyJWT.
Now jwt encode do not return bytes anymore (https://github.com/jpadilla/pyjwt/issues/391) when using Python3 and jwt.decode's verify parameter was deprecated in favor of  options={'verify_signature': ...}.
Besides that, some unused imports were cleaned up.